### PR TITLE
feat: use settings.gradle.kts to find subprojects

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-GOOS=darwin GOARCH=amd64 go build -o gradle-subproject-resolver-amd64 *.go
-GOOS=darwin GOARCH=arm64 go build -o gradle-subproject-resolver-arm64 *.go
-lipo -create -output gradle-subproject-resolver gradle-subproject-resolver-amd64 gradle-subproject-resolver-arm64
+GOOS=darwin GOARCH=amd64 go build -o gradle-subproject-resolver-macos-amd64 *.go
+GOOS=darwin GOARCH=arm64 go build -o gradle-subproject-resolver-macos-arm64 *.go
+lipo -create -output gradle-subproject-resolver-macos gradle-subproject-resolver-macos-amd64 gradle-subproject-resolver-macos-arm64
 
-rm -f gradle-subproject-resolver-amd64 gradle-subproject-resolver-arm64
+rm -f gradle-subproject-resolver-macos-amd64 gradle-subproject-resolver-macos-arm64
+
+GOOS=linux GOARCH=amd64 go build -o gradle-subproject-resolver-linux-amd64 *.go
+GOOS=linux GOARCH=arm64 go build -o gradle-subproject-resolver-linux-arm64 *.go

--- a/gradleparser.go
+++ b/gradleparser.go
@@ -4,22 +4,22 @@ import "regexp"
 
 var projectRegex = regexp.MustCompile(`project\(['"]:?([\w-]+)['"]\)`)
 
-func CreateDependencyMap(gradleFiles map[string]string) map[string][]string {
+func CreateDependencyMap(projectNameToBuildFileContent map[string]string) map[string][]string {
 	dependencyMap := make(map[string][]string)
 
-	for key, val := range gradleFiles {
-		dependencyMap[key] = readDependencies(val)
+	for projectName, projectBuildFileContent := range projectNameToBuildFileContent {
+		dependencyMap[projectName] = readDependencies(projectBuildFileContent)
 	}
 
 	return dependencyMap
 }
 
-func readDependencies(contents string) []string {
-	projectDependencies := projectRegex.FindAllStringSubmatch(contents, -1)
+func readDependencies(projectBuildFileContent string) []string {
+	projectDependencies := projectRegex.FindAllStringSubmatch(projectBuildFileContent, -1)
 
 	directDependencies := make([]string, 0, len(projectDependencies))
-	for _, something := range projectDependencies {
-		directDependencies = append(directDependencies, something[1])
+	for _, projectDependency := range projectDependencies {
+		directDependencies = append(directDependencies, projectDependency[1])
 	}
 
 	return directDependencies

--- a/gradleparser.go
+++ b/gradleparser.go
@@ -2,7 +2,7 @@ package main
 
 import "regexp"
 
-var projectRegex = regexp.MustCompile(`project\(['"]:?([a-z-?A-Z]+)['"]\)`)
+var projectRegex = regexp.MustCompile(`project\(['"]:?([\w-]+)['"]\)`)
 
 func CreateDependencyMap(gradleFiles map[string]string) map[string][]string {
 	dependencyMap := make(map[string][]string)

--- a/gradleparser_test.go
+++ b/gradleparser_test.go
@@ -10,6 +10,7 @@ dependencies {
 	implementation(project(":cool-beans"))
 	api(project(":uncool-beans"))
 	implementation("com.beans.cool")
+	implementation(project(":mambo-no-5"))
 	api("org.beans.cooler")
 }
 `
@@ -40,7 +41,7 @@ func TestParser(t *testing.T) {
 				"alpha": newGradleFormatKt,
 			},
 			map[string][]string{
-				"alpha": {"cool-beans", "uncool-beans"},
+				"alpha": {"cool-beans", "uncool-beans", "mambo-no-5"},
 			},
 		},
 		{

--- a/resolvegradlesubprojects.go
+++ b/resolvegradlesubprojects.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,32 +28,59 @@ func main() {
 		os.Exit(1)
 	}
 
-	gradleFiles, err := readGradleFiles(gradleFilePaths)
+	projectNameToBuildFileContent, err := readAllBuildFiles()
 	if err != nil {
 		fmt.Println("Failed to read gradle files", err)
 		os.Exit(1)
 	}
 
-	allProjectsDependencies := CreateDependencyMap(gradleFiles)
-
+	allProjectsDependencies := CreateDependencyMap(projectNameToBuildFileContent)
 	allDependencies := ResolveDependencies(allProjectsDependencies, subproject)
 
 	fmt.Println(strings.Join(allDependencies, " "))
 }
 
-func readGradleFiles(filePaths []string) (map[string]string, error) {
-	gradleFiles := make(map[string]string)
-	for _, file := range filePaths {
-
-		content, err := ioutil.ReadFile(file)
-		if err != nil {
-			return nil, fmt.Errorf("file %v: %v", file, err)
-		}
-
-		subprojectDirname := filepath.Base(filepath.Dir(file))
-
-		gradleFiles[subprojectDirname] = string(content)
+func readAllBuildFiles() (map[string]string, error) {
+	projectNameToBuildFilePath, err := readProjectSettings()
+	if err != nil {
+		return nil, fmt.Errorf("%v", err)
 	}
 
-	return gradleFiles, nil
+	projectNameToBuildFileContent := make(map[string]string)
+	for projectName, buildFilePath := range projectNameToBuildFilePath {
+		contentBytes, err := os.ReadFile(buildFilePath)
+		if err != nil {
+			return nil, fmt.Errorf("%v", err)
+		}
+		fileContent := string(contentBytes)
+		projectNameToBuildFileContent[projectName] = fileContent
+	}
+
+	return projectNameToBuildFileContent, nil
+}
+
+func readProjectSettings() (map[string]string, error) {
+	allSubprojects, err := readSettingsGradleKts()
+	if err != nil {
+		return nil, fmt.Errorf("%v", err)
+	}
+
+	projectNameToBuildFilePath := make(map[string]string)
+	for projectName, projectDir := range allSubprojects {
+		subprojectBuildFilePath := projectDir + "/build.gradle.kts"
+		projectNameToBuildFilePath[projectName] = subprojectBuildFilePath
+	}
+
+	return projectNameToBuildFilePath, nil
+}
+
+func readSettingsGradleKts() (map[string]string, error) {
+	filename := "settings.gradle.kts"
+	contentBytes, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("file %v: %v", filename, err)
+	}
+	fileContent := string(contentBytes)
+	allSubprojects := FindAllSubprojects(fileContent)
+	return allSubprojects, nil
 }

--- a/settings_gradle_kts_parser.go
+++ b/settings_gradle_kts_parser.go
@@ -7,9 +7,6 @@ import (
 var includeRegex = regexp.MustCompile(`include\("(?P<ProjectName>[\w-]+)"\)`)
 var projectDirRegex = regexp.MustCompile(`project\(":(?P<ProjectName>[\w-]+)"\).projectDir\s?=\s?file\("(?P<ProjectDir>[\w-/]+)"\)`)
 
-//include("demo-fourth")
-//project(":demo-fourth").projectDir = file("cool/libs/demo-fourth")
-
 func FindAllSubprojects(settingsGradleKtsContent string) map[string]string {
 	projectNames := readIncludedProjectNames(settingsGradleKtsContent)
 	projectDirOverrides := readProjectDirectoryOverrides(settingsGradleKtsContent)

--- a/settings_gradle_kts_parser.go
+++ b/settings_gradle_kts_parser.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"regexp"
+)
+
+var includeRegex = regexp.MustCompile(`include\("(?P<ProjectName>[\w-]+)"\)`)
+var projectDirRegex = regexp.MustCompile(`project\(":(?P<ProjectName>[\w-]+)"\).projectDir\s?=\s?file\("(?P<ProjectDir>[\w-/]+)"\)`)
+
+//include("demo-fourth")
+//project(":demo-fourth").projectDir = file("cool/libs/demo-fourth")
+
+func FindAllSubprojects(settingsGradleKtsContent string) map[string]string {
+	projectNames := readIncludedProjectNames(settingsGradleKtsContent)
+	projectDirOverrides := readProjectDirectoryOverrides(settingsGradleKtsContent)
+
+	projectNameToProjectDir := make(map[string]string)
+	for _, projectName := range projectNames {
+		projectNameToProjectDir[projectName] = projectName // by default path is same as project name
+	}
+	for projectName, projectDirOverride := range projectDirOverrides {
+		projectNameToProjectDir[projectName] = projectDirOverride
+	}
+	return projectNameToProjectDir
+}
+
+func readIncludedProjectNames(contents string) []string {
+	projectNameGroupIndex := includeRegex.SubexpIndex("ProjectName")
+
+	matches := includeRegex.FindAllStringSubmatch(contents, -1)
+	includedProjectNames := make([]string, 0, len(matches))
+	for _, match := range matches {
+		projectName := match[projectNameGroupIndex]
+		includedProjectNames = append(includedProjectNames, projectName)
+	}
+	return includedProjectNames
+}
+
+func readProjectDirectoryOverrides(contents string) map[string]string {
+	projectNameGroupIndex := projectDirRegex.SubexpIndex("ProjectName")
+	projectDirGroupIndex := projectDirRegex.SubexpIndex("ProjectDir")
+
+	matches := projectDirRegex.FindAllStringSubmatch(contents, -1)
+
+	includedProjectDirectoryOverrides := make(map[string]string, len(matches))
+
+	for _, match := range matches {
+		projectName := match[projectNameGroupIndex]
+		projectDir := match[projectDirGroupIndex]
+		includedProjectDirectoryOverrides[projectName] = projectDir
+	}
+	return includedProjectDirectoryOverrides
+}

--- a/settings_gradle_kts_parser_test.go
+++ b/settings_gradle_kts_parser_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+const settingsGradleKts = `
+include("demo-third")
+include("demo-fourth")
+project(":demo-fourth").projectDir = file("cool/libs/demo-fourth")
+`
+
+func TestSettingsParser(t *testing.T) {
+	allSubprojects := FindAllSubprojects(settingsGradleKts)
+	expected := map[string]string{
+		"demo-third":  "demo-third",
+		"demo-fourth": "cool/libs/demo-fourth",
+	}
+
+	if !reflect.DeepEqual(allSubprojects, expected) {
+		t.Errorf("CreateDependencyMap(%v) = %v; want %v", settingsGradleKts, allSubprojects, expected)
+	}
+}


### PR DESCRIPTION
It used to search for `gradle.build.kts` files from first level subdirectories, but that can't find build files from nested directories and also won't know the mapping between subproject name and subproject actual directory path (if overridden with `projectDir=...`).

Supported syntax in `settings.gradle.kts`:
- `include("module-name")`
- `project(":module-name").projectDir = file("cool/libs/module-name")`


Example settings.gradle.kts file:
```
include("first-module")

include("second-module")
project(":second-module").projectDir = file("cool/libs/other-module")
```

## Related issues



## Checklist

- [ ] Code is covered with tests.
